### PR TITLE
Fix the find_span function for both cuda and cpu. 

### DIFF
--- a/NURBSDiff/csrc/curve_eval_cuda_kernel.cu
+++ b/NURBSDiff/csrc/curve_eval_cuda_kernel.cu
@@ -20,7 +20,7 @@ __device__ __forceinline__ int find_span(int n, int p, float u, float* U)
       int low  = p;
       int high = n+1; 
       int mid = (low + high)/2;
-      while (u < U[mid]-eps || u >= U[mid+1]+eps){
+      while (u < U[mid]-eps || u >= U[mid+1]-eps){
             if (u < U[mid]-eps)
                   high = mid;
             else

--- a/NURBSDiff/csrc/utils.cpp
+++ b/NURBSDiff/csrc/utils.cpp
@@ -17,7 +17,7 @@ int find_span(int n, int p, float u, float* U)
       int high = n+1; 
       // Do binary search
       int mid = (low + high)/2;
-      while (u < U[mid]-eps || u >= U[mid+1]+eps){
+      while (u < U[mid]-eps || u >= U[mid+1]-eps){
             if (u < U[mid]-eps)
                   high = mid;
             else


### PR DESCRIPTION
The find_span algorithm in the NURBS book is supposed to find the last duplicated knot if the multiplicity is larger than 1. The tolerance for `>=` should be `value-eps`. 