### PR TITLE
del right and left after using them in basis_funs

### DIFF
--- a/NURBSDiff/csrc/surf_eval_cuda_kernel.cu
+++ b/NURBSDiff/csrc/surf_eval_cuda_kernel.cu
@@ -56,7 +56,8 @@ __device__ __forceinline__ void basis_funs(int uspan_i, float u, int p, float* U
     }
     N[i*col+j] = saved;
   }
-
+    delete[] left;   // Free memory after use
+    delete[] right;  // Free memory after use
 }
 
 


### PR DESCRIPTION
The surf_eval_cuda_kernel.cu has memory leakage issue because the float pointer is not deleted after usage.